### PR TITLE
Fix: don't override files with the same name

### DIFF
--- a/harextract.html
+++ b/harextract.html
@@ -281,6 +281,12 @@ function buildZIP (ents, data) {
             let encoding = data[ent.id].response.content.encoding;
             if (encoding != 'base64')
                 throw new Error(`Unsupported encoding for ${ent.name} (${ent.id}): ${encoding}`);
+            if (zip.file(filepath)) {
+                //if filename already exists, add a numbered suffix
+                const count = Number(filepath.match(/^.*_([0-9]*)\.[^\.]*$/)?.at(1));
+                if (count) filepath = filepath.replace(/^(.*_)[0-9]*(\.[^\.]*)$/,`$1${count + 1}$2`);
+                else filepath = filepath.replace(/^(.*)(\.[^\.]*)$/,`$1_2$2`);
+            }
             zip.file(filepath, data[ent.id].response.content.text, { base64: true });
         } catch (e) {
             console.log(e);


### PR DESCRIPTION
I run into a case where there were multiple files in the HAR that had the same filepath and filename. The ZIP would then only include one of them.

This PR alters the filename if there's already one existing and adds a numbered suffix:
file.png  -->  file_2.png -->  file_3.png  ...