### PR TITLE
Fix: add numbered suffix to duplicate filenames instead of overwriting them

### DIFF
--- a/harextract.html
+++ b/harextract.html
@@ -281,6 +281,12 @@ function buildZIP (ents, data) {
             let encoding = data[ent.id].response.content.encoding;
             if (encoding != 'base64')
                 throw new Error(`Unsupported encoding for ${ent.name} (${ent.id}): ${encoding}`);
+            if (zip.file(filepath)) {
+                //if filename already exists, add a numbered suffix
+                const count = Number(filepath.match(/^.*_([0-9]*)\.[^\.]*$/)?.at(1));
+                if (count) filepath = filepath.replace(/^(.*_)[0-9]*(\.[^\.]*)$/,`$1${count + 1}$2`);
+                else filepath = filepath.replace(/^(.*)(\.[^\.]*)$/,`$1_2$2`);
+            }
             zip.file(filepath, data[ent.id].response.content.text, { base64: true });
         } catch (e) {
             console.log(e);

--- a/harextract.html
+++ b/harextract.html
@@ -282,10 +282,21 @@ function buildZIP (ents, data) {
             if (encoding != 'base64')
                 throw new Error(`Unsupported encoding for ${ent.name} (${ent.id}): ${encoding}`);
             if (zip.file(filepath)) {
-                //if filename already exists, add a numbered suffix.
-                const count = Number(filepath.match(/^.*_([0-9]*)\.[^\.]*$/)?.at(1));
-                if (count) filepath = filepath.replace(/^(.*_)[0-9]*(\.[^\.]*)$/,`$1${count + 1}$2`);
-                else filepath = filepath.replace(/^(.*)(\.[^\.]*)$/,`$1_2$2`);
+                // file already exists in the zip so we need to find a unique name for it
+                // split the full path into the folder/directory part and the filename part
+                const slashIdx = filepath.lastIndexOf('/');
+                const dir = slashIdx >= 0 ? filepath.substring(0, slashIdx + 1) : '';
+                const filename = slashIdx >= 0 ? filepath.substring(slashIdx + 1) : filepath;
+                // split the filename into base and extension so we can stick the suffix in before the dot
+                // we use lastIndexOf on just the filename so dots in directory names dont mess things up
+                const dotIdx = filename.lastIndexOf('.');
+                const base = dotIdx >= 0 ? filename.substring(0, dotIdx) : filename;
+                const ext = dotIdx >= 0 ? filename.substring(dotIdx) : '';
+                // start at 2 since the original file already took the unsuffixed slot
+                let counter = 2;
+                // keep incrementing until we find a name thats not already in the zip
+                while (zip.file(`${dir}${base}_${counter}${ext}`)) counter++;
+                filepath = `${dir}${base}_${counter}${ext}`;
             }
             zip.file(filepath, data[ent.id].response.content.text, { base64: true });
         } catch (e) {

--- a/harextract.html
+++ b/harextract.html
@@ -282,7 +282,7 @@ function buildZIP (ents, data) {
             if (encoding != 'base64')
                 throw new Error(`Unsupported encoding for ${ent.name} (${ent.id}): ${encoding}`);
             if (zip.file(filepath)) {
-                //if filename already exists, add a numbered suffix
+                //if filename already exists, add a numbered suffix.
                 const count = Number(filepath.match(/^.*_([0-9]*)\.[^\.]*$/)?.at(1));
                 if (count) filepath = filepath.replace(/^(.*_)[0-9]*(\.[^\.]*)$/,`$1${count + 1}$2`);
                 else filepath = filepath.replace(/^(.*)(\.[^\.]*)$/,`$1_2$2`);


### PR DESCRIPTION
If a HAR file has multiple entries that share the same path and filename, the zip was just _silently_ overwriting them and you would end up with only one file instead of all of them. 

This adds handling so that when a filename collision is detected, instead of overwriting the existing file it appends a numbered suffix to the new one. So if you have 15 files all named `file.ext` you would get `file.ext`, `file_2.ext`, `file_3.ext` and so on for however many there are. 

The way it works is it checks if the filename already exists in the zip, and if it does it tries `file_2.ext`, then `file_3.ext`, and keeps incrementing until it finds a name that isnt taken yet, then writes to that. The filename and extension are split around the last dot after the last slash so that dots in directory names do NOT cause any issues. Files with and without extensions both work fine. 

Credit to xjcb-de who originally started looking into this problem on their fork in October of 2024.